### PR TITLE
Save sit disable player preferences between server restarts

### DIFF
--- a/src/com/cnaude/chairs/commands/ChairsCommand.java
+++ b/src/com/cnaude/chairs/commands/ChairsCommand.java
@@ -41,10 +41,10 @@ public class ChairsCommand implements CommandExecutor {
 		if (sender instanceof Player) {
 			Player player = (Player) sender;
 			if (args[0].equalsIgnoreCase("off")) {
-				plugin.sitDisabled.add(player.getName());
+				plugin.sitDisabled.add(player.getUniqueId());
 				player.sendMessage(plugin.msgDisabled);
 			} else if (args[0].equalsIgnoreCase("on")) {
-				plugin.sitDisabled.remove(player.getName());
+				plugin.sitDisabled.remove(player.getUniqueId());
 				player.sendMessage(plugin.msgEnabled);
 			}
 		}

--- a/src/com/cnaude/chairs/core/Chairs.java
+++ b/src/com/cnaude/chairs/core/Chairs.java
@@ -1,9 +1,14 @@
 package com.cnaude.chairs.core;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -26,7 +31,7 @@ import com.cnaude.chairs.vehiclearrow.NMSAccess;
 
 public class Chairs extends JavaPlugin {
 
-	public HashSet<String> sitDisabled = new HashSet<String>();
+	public HashSet<UUID> sitDisabled = new HashSet<UUID>();
 	public ChairEffects chairEffects;
 	public List<ChairBlock> allowedBlocks;
 	public List<Material> validSigns;
@@ -100,6 +105,7 @@ public class Chairs extends JavaPlugin {
 		log = null;
 		nmsaccess = null;
 		psitdata = null;
+		saveSitDisabled();
 	}
 
 	public void loadConfig() {
@@ -156,6 +162,40 @@ public class Chairs extends JavaPlugin {
 			catch (Exception e) {
 				logError(e.getMessage());
 			}
+		}
+
+		try {
+			File sitDisabledFile = new File(getDataFolder(), "sit-disabled.txt");
+			if (sitDisabledFile.exists()) {
+				String line = null;
+				sitDisabled.clear();
+				BufferedReader br = new BufferedReader(new FileReader(sitDisabledFile));
+				while ((line = br.readLine()) != null) {
+					try {
+						sitDisabled.add(UUID.fromString(line));
+					} catch (IllegalArgumentException e) {
+						/* Not a UUID */
+					}
+				}
+				br.close();
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void saveSitDisabled() {
+		try {
+			File sitDisabledFile = new File(getDataFolder(), "sit-disabled.txt");
+			if (!sitDisabledFile.exists())
+				sitDisabledFile.createNewFile();
+			PrintWriter writer = new PrintWriter(sitDisabledFile, "UTF-8");
+			writer.println("# The following players disabled Chairs for themselves");
+			for (UUID uuid : sitDisabled)
+				writer.println(uuid.toString());
+			writer.close();
+		} catch (IOException e) {
+			e.printStackTrace();
 		}
 	}
 

--- a/src/com/cnaude/chairs/listeners/TrySitEventListener.java
+++ b/src/com/cnaude/chairs/listeners/TrySitEventListener.java
@@ -44,7 +44,7 @@ public class TrySitEventListener implements Listener {
 	private boolean sitAllowed(Player player, Block block) {
 
 		// Check for sitting disabled
-		if (plugin.sitDisabled.contains(player.getName())) {
+		if (plugin.sitDisabled.contains(player.getUniqueId())) {
 			return false;
 		}
 


### PR DESCRIPTION
Hello,
And thanks for maintaining this cool plugin!
We're using it with lots on fun on https://hellominecraft.fr/ :)

Some of our players complained about having to perform `/chairs off` after every server restart, mainly because they do not wish to sit down, or because of side effects while building with stairs blocks.

This contribution allows saving/loading the `sitDisabled` list between restarts using a file named `sit-disabled.txt`, placed in the same directory as `config.yml`. This file is automatically created on first plugin disable, with a comment on first line telling why this file exists. The additional code has been written in a Java 6 compatible way so it should'nt add additional requirements to the project.

Also upgraded the list from usernames to UUID by the way, since it's now saved permanently.
